### PR TITLE
Fix typos in varcon README and comments

### DIFF
--- a/varcon/README
+++ b/varcon/README
@@ -27,7 +27,7 @@ indicated by the "A") of the word, and "acknowledgement" is the
 preferred Canadian and British spelling ("B" and "C").  However the
 American spelling is sometimes used in Canada (as indicated by "Cv",
 where the lowercase "v" indicated a variant form) and the British
-spelling is sometimes used in America (as indicated the the "Av").
+spelling is sometimes used in America (as indicated the "Av").
 
 More generally each tag consists of a spelling category (for example
 "A") followed possible by a variant indicator.  The spelling
@@ -53,8 +53,8 @@ as variants in the dictionary.  However, some variants will be demoted
 to a "V".  For example, if the variant is marked as "also" by
 Merriam-Webster, or also if only some dictionaries acknowledge the
 existence the variant.  "-" is used when the variant is generally not
-listed is the dictionary but I could find some evidence of it use, or
-when it is it marked as as a archaic spelling for the word.  The "x"
+listed is the dictionary but I could find some evidence of its use, or
+when it is marked as an archaic spelling for the word.  The "x"
 is used when the spelling is almost generally considered a
 misspelling, and is only included for completeness.
 
@@ -106,8 +106,8 @@ Sometimes part-of-speech (POS) info is given to help distinguish which
 form is used.  For example:
   A B C: practice / AV Cv: practise | <N>
   A Cv: practice / AV B C: practise | <V>
-POS info is always given given in the form "<POS>" and if a definition
-is also given the the POS info is always first.  The POS tags used are as
+POS info is always given in the form "<POS>" and if a definition
+is also given the POS info is always first.  The POS tags used are as
 follows:
   <N>: Noun
   <V>: Verb
@@ -132,7 +132,7 @@ the cluster and are prefixed with "##", for example:
   A B C: coloration / B. Cv: colouration
   A B C: colorations / B. Cv: colourations
   A B C: coloration's / B. Cv: colouration's
-  ## OED has coloration as the prefered spelling and discolouration as a
+  ## OED has coloration as the preferred spelling and discolouration as a
   ## variant for British Engl or some reason
 In the notes ODE (not to be confused with OED) stands for Oxford
 Dictionary of English, "Ox" is used for any Oxford dictionary, and

--- a/varcon/varcon.txt
+++ b/varcon/varcon.txt
@@ -4781,7 +4781,7 @@ A: colorate / B: colourate
 A B C: coloration / B. Cv: colouration
 A B C: colorations / B. Cv: colourations
 A B C: coloration's / B. Cv: colouration's
-## OED has coloration as the prefered spelling and discolouration as a
+## OED has coloration as the preferred spelling and discolouration as a
 ## variant for British English for some reason
 
 # colorational (level 95)
@@ -11221,7 +11221,7 @@ A B: gluing / AV Bv: glueing
 
 # gluteal <verified> (level 70)
 A B: gluteal / BV: glutaeal
-## OED has glutaeal listed first, ODE doesn't reconize glutaeal
+## OED has glutaeal listed first, ODE doesn't recognize glutaeal
 
 # gluteus (level 70)
 A: gluteus / B: glutaeus
@@ -18302,7 +18302,7 @@ A Z: niggardizes / B: niggardises
 A B: night / Av: nite
 A B: nights / Av: nites
 A B: night's / Av: nite's
-## Ox lables nite as an informal spelling
+## Ox labels nite as an informal spelling
 
 # nightie (level 40)
 _: nightie / _v: nighty
@@ -32403,7 +32403,7 @@ A: zygenid / B: zygaenid
 _: Koran / _.: Quran / _v: Qur'an
 ## Quran is more correct bases on a modern transliterated from Arabic
 ## to English, but both M-W and Oxford has Koran marked as the primary
-## form.  Tecnically "Qur'an" more correct but that doesn't seam to be
+## form.  Technically "Qur'an" more correct but that doesn't seam to be
 ## used as much.
 
 # Koranic (level 60)


### PR DESCRIPTION
Found mostly using [mwic](http://jwilk.net/software/mwic).