### PR TITLE
Change scowl scripts using "echo -n" to /bin/bash

### DIFF
--- a/scowl/src/list-classes
+++ b/scowl/src/list-classes
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ "$1" != -1 ]
 then

--- a/scowl/src/list-combin
+++ b/scowl/src/list-combin
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 spellings="`src/list-spellings`"
 classes="`src/list-classes`"

--- a/scowl/src/list-spellings
+++ b/scowl/src/list-spellings
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ "$1" != -1 ]
 then

--- a/scowl/src/split-words-deps
+++ b/scowl/src/split-words-deps
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 echo -n src/split-words  
 echo -n '' working/variant_1.lst


### PR DESCRIPTION
This fixes an issue building from source on macOS Sierra and higher.
/bin/sh on macOS prints a literal "-n" and this causes build errors.
GNU findutils are also required to build and do not come preinstalled.
`brew install findutils` should install what you need, and don't forget
to put it on the PATH:

```
PATH=/usr/local/opt/findutils/libexec/gnubin:/usr/bin:/bin /usr/bin/make
```

Fixes #198.