### PR TITLE
Add two racial epithets to the offensive words list.

### DIFF
--- a/scowl/misc/offensive.1
+++ b/scowl/misc/offensive.1
@@ -1,3 +1,7 @@
+nigga
+nigga's
+niggas
+niggaz
 nigger
 nigger's
 niggered


### PR DESCRIPTION
The 'mainstream', for want of a better word, spelling of
this particular epithet is already present in this list,
and this commit extends this to cover offensive variants
encountered in Firefox (Bug [1654098](https://bugzilla.mozilla.org/show_bug.cgi?id=1654098)) and CEF.

This change includes the plural and possessive forms, following the style in the file.