### PR TITLE
fix exclude arg in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ keep them:
 
 To exclude abbreviations altogether (including unmarked ones):
 
-    ./scowl word-list 60 A 1 --poses-to-exclude=abbr > wl.txt
+    ./scowl word-list 60 A 1 --wo-poses=abbr > wl.txt
 
 To disable the word filter and include all words:
 
@@ -902,7 +902,7 @@ example is equivalent to:
 
     ? cohost <v>
     cohost <m→v>
-  
+
 #### Examples
 
 The most straightforward use of an _adjust_ file is to add variant info.  For


### PR DESCRIPTION
I know this is tiny but it took me a few minutes after seeing exclude args don't exist to find --wo instead (I assume without?)

```
./scowl word-list 60 A 1 --poses-to-exclude=abbr       

usage: scowl [-h] [--db <file>] <command> ...
scowl: error: unrecognized arguments: --poses-to-exclude=abbr
```