### PR TITLE
Fix en_CA REP rule incorrectly suggesting British -ise over Canadian -ize

### DIFF
--- a/speller/en.aff
+++ b/speller/en.aff
@@ -112,7 +112,7 @@ SFX B   e     able       [^aeiou]e
 SFX L Y 1
 SFX L   0     ment       .
 
-REP 90
+REP 89
 REP a ei
 REP ei a
 REP a ey
@@ -202,4 +202,3 @@ REP ss z
 REP shun tion
 REP shun sion
 REP shun cion
-REP size cise


### PR DESCRIPTION
Removes 'REP size cise' rule from en.aff which was causing words like
'realize', 'organize', 'recognize' etc. to be incorrectly flagged in
favour of their British -ise forms. Canadian English standardly uses
-ize endings, so this rule produced incorrect behaviour for Canadian
users.

Fixes #508
