### PR TITLE
Add "watchlist"

### DIFF
--- a/data/extra
+++ b/data/extra
@@ -1036,6 +1036,10 @@
 # Issue #460
 60: voxel <n>: voxels, voxel's
 
+# Issue #523
+60: _: watchlist <n>: watchlists, watchlist's
+60: _?: watch list <n>: watch lists, watch list's
+
 # Issue #337
 60: wheatgrass <n>
 70: - <n>: wheatgrasses-


### PR DESCRIPTION
Closes en-wl#523

Added the open form as a variant, as per [docs/policy.md](../blob/v2/docs/policy.md).

I used the `?` variant level since dictionaries seem to be split over which of these forms is the headword:

- [Merriam-Webster](https://www.merriam-webster.com/dictionary/watch%20list), [Cambridge](https://dictionary.cambridge.org/dictionary/english/watch-list) and [Oxford](https://www.oed.com/dictionary/watch-list_n) list the open form only, although Cambridge marks the closed form as "also".
- [Collins](https://www.collinsdictionary.com/dictionary/english/watchlist) and [Dictionary.com](https://www.dictionary.com/browse/watchlist) list both as separate entries.
- [Wiktionary](https://en.wiktionary.org/wiki/watchlist) lists the open form as the headword and the closed form as merely a variant.

Also worth noting that Collins and Dictionary.com mark the open form as American, and Dictionary.com also marks the closed form as British. But this does not seem to be universal and both have sourced example sentences that contradict these claims.