### PR TITLE
Add antizionism, antizionist

### DIFF
--- a/data/extra
+++ b/data/extra
@@ -15,6 +15,13 @@
 # Issue #472
 60: Anthropic <n/name>: Anthropic's
 
+60: antizionism <n>
+80: - <n>: antizionisms~
+
+70: antizionist <n>
+
+60: antizionist <aj>
+
 # Issue #344
 60: Aotearoa <n/place>: Aotearoa's
 


### PR DESCRIPTION
Adds `antizionism` as a noun at size 60.

The term is currently absent from ESDB, while `antisemitism` is already included at size 60:

```
$ ./scowl search --exact antisemitism
60: antisemitism <n>
80: - <n>: antisemitisms~

$ ./scowl search --exact anti-Zionism
# no results

$ ./scowl search --exact antizionism
# no results
``` 

The fused form is attested in edited institutional, journalistic, and scholarly English, including:

- [Government of Canada / Canadian Heritage, Campus Antisemitism and Student Experiences (2026)](https://www.canada.ca/en/canadian-heritage/services/canada-holocaust/antisemitism/campus-antisemitism-student-experiences.html)
- [The Globe and Mail, “Canadians need answers from Ottawa on foreign involvement in antisemitism” (editorial, 2026)](https://www.theglobeandmail.com/opinion/editorials/article-antisemitism-jewish-canadians-federal-government-foreign-entity/)
- [Journal of Contemporary Antisemitism, “Durban Antizionism: Its Sources, its Impact, and its Relation to Older Anti-Jewish Ideologies” (2022)](https://doi.org/10.26613/jca/5.1.98)

Size 60 seems appropriate given the term's established use in edited general-audience, institutional, and scholarly English.

Verification:
```
$ ./scowl search --exact antizionism
60 [extra]: antizionism <n>

$ ./scowl word-list 60 A 1 | grep -x antizionism
antizionism
```

make completes successfully.